### PR TITLE
Add variables to query

### DIFF
--- a/packages/gatsby-theme-twentynineteen/utils/createCategories.js
+++ b/packages/gatsby-theme-twentynineteen/utils/createCategories.js
@@ -5,9 +5,9 @@ const categoryTemplate = require.resolve(
 
 module.exports = async ({ actions, graphql }) => {
   const GET_CATEGORIES = `
-    query GET_CATEGORIES($first: Int) {
+    query GET_CATEGORIES($first: Int $after: String) {
       wpgraphql { 
-        categories(first: $first) {
+        categories(first: $first, after: $after) {
           pageInfo {
             hasNextPage
             endCursor

--- a/packages/gatsby-theme-twentynineteen/utils/createTags.js
+++ b/packages/gatsby-theme-twentynineteen/utils/createTags.js
@@ -3,9 +3,9 @@ const tagTemplate = require.resolve(`../src/templates/tags/archive.js`)
 
 module.exports = async ({ actions, graphql }) => {
   const GET_TAGS = `
-    query GET_TAGS($first: Int) {
+    query GET_TAGS($first: Int $after: String) {
       wpgraphql { 
-        tags(first: $first) {
+        tags(first: $first, after: $after) {
           pageInfo {
             hasNextPage
             endCursor

--- a/packages/gatsby-theme-twentynineteen/utils/createUsers.js
+++ b/packages/gatsby-theme-twentynineteen/utils/createUsers.js
@@ -3,9 +3,9 @@ const userTemplate = require.resolve(`../src/templates/users/archive.js`)
 
 module.exports = async ({ actions, graphql }) => {
   const GET_USERS = `
-    query GET_USERS($first: Int) {
+    query GET_USERS($first: Int $after: String) {
       wpgraphql { 
-        users(first: $first) {
+        users(first: $first, after: $after) {
           pageInfo {
             hasNextPage
             endCursor


### PR DESCRIPTION
This simply adds the `after` variable to the query for sites that have greater than the $first variable on tags, categories and users. This caused an endless loop if you had more than that as it would always be "after" the first cursor always.